### PR TITLE
Log filter

### DIFF
--- a/app/controllers/worker_logs_controller.rb
+++ b/app/controllers/worker_logs_controller.rb
@@ -1,6 +1,40 @@
 class WorkerLogsController < ApplicationController
   def index
-    @logs = WorkerLog.all.desc('$natural').where(l: {'$gt': 0}).limit(100)
+    @filtering = false
+    @level = '-10'
+    @tstart = ''
+    @tend = ''
+    @kwd = ''
+    if params['commit'] == nil
+      @logs = WorkerLog.all.desc('$natural').where(l: {'$gt': 0}).limit(100)
+      return
+    end
+
+    @filtering = true
+    query_level = nil
+    query_tstart = nil
+    query_tend = nil
+    query_kwd = nil
+    if params['severity'] != nil && params['severity'] != ''
+      @level = params['severity']
+      query_level = {l: {'$gt': params['severity'].to_i}}
+    end
+    if params['duration_start'] != nil && params['duration_start'] != ''
+      @tstart = params['duration_start']
+      query_tstart = {created_at: {'$gt': params['duration_start'].in_time_zone}}
+    end
+    if params['duration_end'] != nil && params['duration_end'] != ''
+      @tend = params['duration_end']
+      query_tend = {created_at: {'$lt': params['duration_end'].in_time_zone}}
+    end
+    if params['match_keyword'] != nil && params['match_keyword'] != ''
+      ctx_kwd = params['match_keyword']
+      @kwd = params['match_keyword']
+      query_kwd = {m: /#{ctx_kwd}/}
+    end
+
+    query_set = [query_level, query_tstart, query_tend, query_kwd]
+    @logs = WorkerLog.all.desc('$natural').all_of(query_set)
   end
 
   def _contents

--- a/app/views/worker_logs/_filtering.html.haml
+++ b/app/views/worker_logs/_filtering.html.haml
@@ -1,0 +1,17 @@
+%h3 Filter
+%form
+  .form-inline
+    .form-group
+      - severity_level = {"all" => -10, "FATAL" => 3, "ERROR" => 2, "WARN" => 1, "INFO" => 0, "DEBUG" => -1}
+      = select_tag 'severity', options_for_select(severity_level, selected:@level), id:'sever_sel', class:'form-control'
+      &thinsp;
+      %label duration:
+      = text_field_tag(:'duration_start', @tstart, size:10, class:'form-control')
+      \~
+      = text_field_tag(:'duration_end', @tend, size:10, class:'form-control')
+      &thinsp;
+      %label Message includes
+      = search_field_tag('match_keyword', @kwd, class:'form-control')
+      &thinsp;
+      = submit_tag "Apply"
+

--- a/app/views/worker_logs/index.html.haml
+++ b/app/views/worker_logs/index.html.haml
@@ -1,5 +1,23 @@
 .page-header
   %h1 Logs
+  .well
+    %h3 Filter
+    %form
+      .form-inline
+        .form-group
+          - severity_level = {"all" => -1, "FATAL" => 4, "ERROR" => 3, "WARN" => 3, "INFO" => 1, "DEBUG" => 0}
+          = select_tag 'severity', options_for_select(severity_level, selected: severity_level[0]), id:'sever_sel', class:'form-control'
+          &thinsp;
+          %label duration:
+          = text_field_tag(:'duration_start', '', size:10, class:'form-control')
+          \~
+          = text_field_tag(:'duration_end', '', size:10, class:'form-control')
+          &thinsp;
+          %label keyword match
+          = search_field_tag('match_keyword', '', class:'form-control')
+          &thinsp;
+          %a.btn.btn-primary.btn-sm{href: '.'} Apply
+    
 %table.table.table-striped.table-condensed{style: "font-size: smaller;"}
   %thead
     %tr

--- a/app/views/worker_logs/index.html.haml
+++ b/app/views/worker_logs/index.html.haml
@@ -1,23 +1,7 @@
 .page-header
   %h1 Logs
   .well
-    %h3 Filter
-    %form
-      .form-inline
-        .form-group
-          - severity_level = {"all" => -1, "FATAL" => 4, "ERROR" => 3, "WARN" => 3, "INFO" => 1, "DEBUG" => 0}
-          = select_tag 'severity', options_for_select(severity_level, selected: severity_level[0]), id:'sever_sel', class:'form-control'
-          &thinsp;
-          %label duration:
-          = text_field_tag(:'duration_start', '', size:10, class:'form-control')
-          \~
-          = text_field_tag(:'duration_end', '', size:10, class:'form-control')
-          &thinsp;
-          %label keyword match
-          = search_field_tag('match_keyword', '', class:'form-control')
-          &thinsp;
-          %a.btn.btn-primary.btn-sm{href: '.'} Apply
-    
+    = render "filtering"
 %table.table.table-striped.table-condensed{style: "font-size: smaller;"}
   %thead
     %tr
@@ -30,6 +14,8 @@
 
 :javascript
   $(function() {
+    var dont_reload = #{@filtering}
+    if ( dont_reload ) return
     function reload_table() {
       $.get("/worker_logs/_contents", function(data) {
         $('#log_table_body').html(data);
@@ -37,5 +23,5 @@
     };
     setInterval( function() {
       reload_table();
-    }, 5000 );
+    }, 10000 );
   });


### PR DESCRIPTION
LogsページのFilter機能を実装しました。
ページ上部のFilterセクションで条件を設定し、「Apply」を押すとDBにある全てのログを対象にフィルタリングします。元々のフィルタリング無しの表示では直近100件だけを表示し、5秒毎にリロードされますが、「Apply」を押した場合は全件が対象で、リロードはしないようにしています。従って、条件を何も入れず「Apply」を押すと、DB上の全てのログが表示されます。
フィルタリングした状態でのリロードは再度「Apply」を押し、フィルタリング無しにするにはトップメニューの「Logs」をクリックします。