### PR TITLE
Sim param order

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -62,6 +62,13 @@ function exchange_form_order(me, em) {
 
 $(document).ready( function() {
   $('form').on('click', '.remove_fields', function() {
+    var me = $(this).closest('.parameter-definition-field')[0];
+    var res = confirm("Are you sure to remove the parameter: " +
+                      me.children[0].children[0].children[0].value);
+    if ( ! res ) {
+      event.preventDefault();
+      return;
+    }
     $(this).closest('.parameter-definition-field').next('input[type=hidden]').val(true);
     $(this).closest('.parameter-definition-field').remove();
     event.preventDefault();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,4 +58,24 @@ $(document).ready( function() {
       position_to_add.before($(this).data('fields').replace(regexp, time));
       event.preventDefault();
   });
+  $('form').on('click', '.up_fields', function() {
+    var me = $(this).closest('.parameter-definition-field')[0];
+    var p_lst =  $('.parameter-definition-field');
+    var idx, em = null;
+    for ( idx = 0; idx < p_lst.length; idx++ ) {
+      if ( p_lst[idx] === me ) {
+        em = p_lst[idx];
+        break;
+      }
+    }
+    if ( em == null || idx < 1 ) {
+      event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+  });
+  $('form').on('click', '.down_fields', function() {
+    var me = $(this).closest('.parameter-definition-field')[0]
+    event.preventDefault();
+  });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,7 +43,23 @@ $(document).ready(function () {
     });
 });
 
-// add/remove nested forms
+// add/remove/Up/Down nested forms
+
+function exchange_form_order(me, em) {
+  var my_name = me.children[0].children[0].children[0].value;
+  var my_type = me.children[0].children[1].children[0].value;
+  var my_dval = me.children[0].children[2].children[0].value;
+  var my_desc = me.children[1].children[0].children[0].value;
+  me.children[0].children[0].children[0].value = em.children[0].children[0].children[0].value;
+  me.children[0].children[1].children[0].value = em.children[0].children[1].children[0].value;
+  me.children[0].children[2].children[0].value = em.children[0].children[2].children[0].value;
+  me.children[1].children[0].children[0].value = em.children[1].children[0].children[0].value;
+  em.children[0].children[0].children[0].value = my_name;
+  em.children[0].children[1].children[0].value = my_type;
+  em.children[0].children[2].children[0].value = my_dval;
+  em.children[1].children[0].children[0].value = my_desc;
+}
+
 $(document).ready( function() {
   $('form').on('click', '.remove_fields', function() {
     $(this).closest('.parameter-definition-field').next('input[type=hidden]').val(true);
@@ -72,10 +88,26 @@ $(document).ready( function() {
       event.preventDefault();
       return;
     }
-    event.preventDefault();
+    em = p_lst[idx - 1];
+    exchange_form_order(me, em);
+    window.refresh();
   });
   $('form').on('click', '.down_fields', function() {
-    var me = $(this).closest('.parameter-definition-field')[0]
-    event.preventDefault();
+    var me = $(this).closest('.parameter-definition-field')[0];
+    var p_lst =  $('.parameter-definition-field');
+    var idx, em = null;
+    for ( idx = 0; idx < p_lst.length; idx++ ) {
+      if ( p_lst[idx] === me ) {
+        em = p_lst[idx];
+        break;
+      }
+    }
+    if ( em == null || idx >= p_lst.length - 1 ) {
+      event.preventDefault();
+      return;
+    }
+    em = p_lst[idx + 1];
+    exchange_form_order(me, em);
+    window.refresh();
   });
 });

--- a/app/views/executable/_parameter_definition_fields.html.haml
+++ b/app/views/executable/_parameter_definition_fields.html.haml
@@ -7,9 +7,13 @@
       = f.select :type, ParametersUtil::TYPES, {}, disabled: disabled, class: 'form-control'
     .col-md-3
       = f.text_field :default, placeholder: "Default value", class: 'form-control'
+    - unless disabled
+      = link_to "Up ", '#', class: "up_fields"
+    - unless disabled
+      = link_to "Down", '#', class: "down_fields"
   .form-group.row.no-margin.no-gutter
     .col-md-8
       = f.text_area :description, placeholder: "Description", rows: 3, class: 'form-control'
     - unless disabled
-      = link_to raw('<i class="fa fa-trash-o">'), '#', class: "remove_fields"
+      = link_to sanitize('<i class="fa fa-trash-o"/>'), '#', class: "remove_fields"
 = f.hidden_field :_destroy

--- a/app/views/executable/_parameter_definition_fields.html.haml
+++ b/app/views/executable/_parameter_definition_fields.html.haml
@@ -11,5 +11,5 @@
     .col-md-8
       = f.text_area :description, placeholder: "Description", rows: 3, class: 'form-control'
     - unless disabled
-      = link_to "remove", '#', class: "remove_fields"
+      = link_to raw('<i class="fa fa-trash-o">'), '#', class: "remove_fields"
 = f.hidden_field :_destroy


### PR DESCRIPTION
シミュレータのパラメータ定義順序入替え機能を実装しました。
Up/Downのフィールドについて、設計書では矢印のシンボルを表示することになっていましたが、Font Awesomeのイメージ表示がうまく行かなかったため、とりあえず文字で表示しています。ゴミ箱はfa-trash-oに変更しました。
また、ゴミ箱をクリックした際(パラメータのremove)にconfirmする処理を追加しています。
一点、気になっているのは、シミュレータの「編集」を行う際に、パラメータ編集がdisabledになる場合とならない場合がある点ですが、とりあえずremove同様にdisabledでない場合のみにUp/Downのフィールドを表示するようにしています。