### PR TITLE
Implemented toggle status of host, added route _toggle_host

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -33,6 +33,22 @@ class HostsController < ApplicationController
     render plain: status
   end
 
+  # toggle remote scheduler status
+  def _toggle_status
+    xhost = Host.find(params[:id])
+    if (xhost.status == :enabled)
+      xhost.status = :disabled
+    else
+      xhost.status = :enabled
+    end
+    xhost.save
+    @host = xhost
+
+    @hosts = Host.asc(:position).all
+    @host_groups = HostGroup.asc(:created_at).all
+    redirect_to action: 'index'
+  end
+
   # GET /hosts/new
   # GET /hosts/new.json
   def new

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -5,7 +5,7 @@ module HostsHelper
     when :enabled
       '<span class="label label-success">enabled</span>'
     when :disabled
-      '<span class="label label-important">disabled</span>'
+      '<span class="label label-default">disabled</span>'
     else
       "<span class=\"label\">#{status}</span>"
     end

--- a/app/views/hosts/index.html.haml
+++ b/app/views/hosts/index.html.haml
@@ -18,7 +18,7 @@
     - @hosts.each do |host|
       = content_tag_for :tr, host do
         %td= link_to(host.name, host)
-        %td= raw(host_status_label(host.status))
+        %td= link_to(raw(host_status_label(host.status)), _toggle_host_path(host))
         %td= host.work_base_dir
         %td= host.mounted_work_base_dir
         %td= host.max_num_jobs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/hosts/:id/_toggle', to: 'hosts#_toggle_status', as: '_toggle_host'
+
   host_group_actions = ["show"]
   host_group_actions += ["new", "create", "edit", "update", "destroy"] unless OACIS_READ_ONLY
   resources :host_groups, only: host_group_actions do


### PR DESCRIPTION
Hostsページのhostのstatus欄クリックで、enabled/disabledを切り替える機能を実装しました。
この機能に対応して_toggle_hostというrouteを追加し、host_controllerに_toggle_statusというActionを追加しています。
disable時のラベルアイコンは元々Bootstrapのlabel-importantが指定されていましたが、現在使用しているバージョンでは表示されなかったため、label-defaultに変更しています。