### PR TITLE
Host status

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -38,11 +38,10 @@ class HostsController < ApplicationController
     xhost = Host.find(params[:id])
     if (xhost.status == :enabled)
       xhost.status = :disabled
+      xhost.update_attribute(:status, :disabled)
     else
-      xhost.status = :enabled
+      xhost.update_attribute(:status, :enabled)
     end
-    xhost.save
-    @host = xhost
 
     @hosts = Host.asc(:position).all
     @host_groups = HostGroup.asc(:created_at).all

--- a/app/views/hosts/index.html.haml
+++ b/app/views/hosts/index.html.haml
@@ -6,6 +6,7 @@
     %tr
       %th Name
       %th Status
+      %th 
       %th Work base dir
       %th Mounted work base dir
       %th Max # of jobs
@@ -19,6 +20,7 @@
       = content_tag_for :tr, host do
         %td= link_to(host.name, host)
         %td= link_to(raw(host_status_label(host.status)), _toggle_status_host_path(host))
+        %td= link_to sanitize('<i class="fa fa-power-off"/>'), _toggle_status_host_path(host)
         %td= host.work_base_dir
         %td= host.mounted_work_base_dir
         %td= host.max_num_jobs

--- a/app/views/hosts/index.html.haml
+++ b/app/views/hosts/index.html.haml
@@ -18,7 +18,7 @@
     - @hosts.each do |host|
       = content_tag_for :tr, host do
         %td= link_to(host.name, host)
-        %td= link_to(raw(host_status_label(host.status)), _toggle_host_path(host))
+        %td= link_to(raw(host_status_label(host.status)), _toggle_status_host_path(host))
         %td= host.work_base_dir
         %td= host.mounted_work_base_dir
         %td= host.max_num_jobs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,13 +87,12 @@ Rails.application.routes.draw do
   resources :hosts, only: host_actions do
     member do
       get '_check_scheduler_status'
+      get '_toggle_status'
     end
     collection do
       post "_sort" # for ajax, update order of the table
     end
   end
-
-  get '/hosts/:id/_toggle', to: 'hosts#_toggle_status', as: '_toggle_host'
 
   host_group_actions = ["show"]
   host_group_actions += ["new", "create", "edit", "update", "destroy"] unless OACIS_READ_ONLY


### PR DESCRIPTION
Hostのステータス変更機能について、以下の修正を行いました。
・ステータス変更のroutes記述を変更
・コントローラーにおいてhostのsaveを止め、update_attributeを行うように変更
・コントローラーにおいて@hostへの代入を削除
・Hostsテーブルのstatus欄の横にスイッチアイコンを追加

status欄の隣に配置するアイコンにはfa-power-offを使用してみました。いかがでしょうか。